### PR TITLE
Fix run file by using 2nd string in Jenkins' job name

### DIFF
--- a/run
+++ b/run
@@ -1,10 +1,10 @@
 #-!/bin/bash
 
-# project.test_type.test_env
+# project.test_env
 # ${JOB_NAME} is a Jenkins var
 
 
 IFS="." read -ra array <<< "${JOB_NAME}"
-TEST_ENV=${array[2]}
+TEST_ENV=${array[1]}
 docker pull firefoxtesteng/kinto-webextensions-tests:latest
 docker run --rm -e TEST_ENV=$TEST_ENV firefoxtesteng/kinto-webextensions-tests:latest


### PR DESCRIPTION
@chartjes r?

This fixes the Jenkins job.

Broken, before: https://qa-master.fxtest.jenkins.stage.mozaws.net/job/kintowe.stage/2/

Fixed: https://qa-master.fxtest.jenkins.stage.mozaws.net/job/kintowe.stage/3/