### PR TITLE
Pluralize config-tests, rather than config-test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /src
 COPY . /src
 RUN pip3 install pipenv
 RUN pipenv install --system
-CMD pytest --env=$TEST_ENV -v config-test/
+CMD pytest --env=$TEST_ENV -v config-tests/


### PR DESCRIPTION
@chartjes r?

This gets the tests running again (see https://qa-master.fxtest.jenkins.stage.mozaws.net/job/kintowe.stage/12/ ) but they are failing, now, for another, different reason.

Here's the erroring-out run, from master: https://gist.github.com/stephendonner/d325136c254fa2b71b4c30d645a2c378
Here's my run with the change: https://gist.github.com/stephendonner/2d6063521cf7d1e9a99f3d3489fe06a4

/cc @glasserc 